### PR TITLE
Fix LIBUSB_ERROR_BUSY on Ubuntu

### DIFF
--- a/co2_monitor.js
+++ b/co2_monitor.js
@@ -79,13 +79,15 @@ class CO2Monitor extends EventEmitter {
      */
     disconnect (callback) {
         this._endpoint.stopPoll(() => {
-            if (os.platform() === 'linux') {
-                this._interface.attachKernelDriver();
-            }
             this._interface.release(true, (err) => {
                 if (err) {
                     this.emit('error', err);
                 }
+
+                if (os.platform() === 'linux') {
+                    this._interface.attachKernelDriver();
+                }
+
                 this._device.close();
                 this.emit('disconnect');
                 return callback(err);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "node-co2-monitor",
   "description": "Node.JS library for reading CO2 concentration and indoor temperature from TFA Dostmann AirCO2NTROL Mini.",
   "license": "MIT",
-  "version": "0.2.1",
+  "version": "0.2.2-dev",
   "author": {
     "name": "Hamhire Hu",
     "email": "me@huhamhire.com",


### PR DESCRIPTION
On Ubuntu I get the following error when stopping the [co2-monitor](https://github.com/huhamhire/co2-monitor-exporter):

```
$ co2-exporter
^C./node_modules/usb/usb.js:326
	return this.device.__attachKernelDriver(this.id)
	                   ^

Error: LIBUSB_ERROR_BUSY
    at Error (native)
    at Interface.attachKernelDriver (./node_modules/usb/usb.js:326:21)
    at InEndpoint._endpoint.stopPoll (./node_modules/node-co2-monitor/co2_monitor.js:83:33)
    at InEndpoint.g (events.js:292:16)
    at emitNone (events.js:86:13)
    at InEndpoint.emit (events.js:185:7)
    at Transfer.transferDone (./node_modules/usb/usb.js:450:10)
```

It seems that the interface has to be released before the kernel driver is attached again.